### PR TITLE
Handle all exceptions properly and return the detail of that exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
           pip install tox
       - name: run tox test py${{ matrix.python-version }}
         run: |
-          tox -e py${{ matrix.python-version }}
+          tox -e py${{ matrix.python-version }} --recreate
       - name: run tox codestyle
         run: |
-          tox -e codestyle
+          tox -e codestyle --recreate
       - name: run tox type
         run: |
-          tox -e type
+          tox -e type --recreate

--- a/patata/client.py
+++ b/patata/client.py
@@ -302,7 +302,9 @@ class Requester:
                 return Response(
                     id_=request.id_, status_code=status_code, data=response_json
                 )
-        except Exception as e:  # TODO: handle all possible exceptions and return the proper code
+        except (
+            Exception
+        ) as e:  # TODO: handle all possible exceptions and return the proper code
             if verbose:
                 logger.exception(e)
             error_data = {


### PR DESCRIPTION
When the API was collapsed or returns a response that is not JSON the aiohttp library raises an exception that when raised inside of multiprocessing causes the client to hang, all requests stop but the client doesn't fail gracefully.

This PR handles all these exceptions and populates Response objects with the details of these exceptions, but continues with the next request without hanging.